### PR TITLE
Timeout for a Request in the WebSocketRequestReplyStub

### DIFF
--- a/packages/rpc/common/src/ts/websocket/WebSocketRequestReplyStub.ts
+++ b/packages/rpc/common/src/ts/websocket/WebSocketRequestReplyStub.ts
@@ -16,7 +16,7 @@ export class WebSocketRequestReplyStub implements RequestReplyStub {
     public async execute<ReplyT, ArgsT>(method: string, args: ArgsT): ReplyPromise<ReplyT> {
         const requestId: number = this.sequential.next();
         const result = new Promise<Reply<ReplyT>>((resolve) => {
-            setTimeout(() => resolve(resolve(errStatus("Timeout"))), 2000)
+            setTimeout(() => resolve(resolve(errStatus('Timeout'))), 2000)
             this.socket.onClose(message => resolve(errStatus(message)));
             this.socket.onMessage(data => {
                 const message = parse<SerializedReply<ReplyT>>(data);

--- a/packages/rpc/common/src/ts/websocket/WebSocketRequestReplyStub.ts
+++ b/packages/rpc/common/src/ts/websocket/WebSocketRequestReplyStub.ts
@@ -16,7 +16,7 @@ export class WebSocketRequestReplyStub implements RequestReplyStub {
     public async execute<ReplyT, ArgsT>(method: string, args: ArgsT): ReplyPromise<ReplyT> {
         const requestId: number = this.sequential.next();
         const result = new Promise<Reply<ReplyT>>((resolve) => {
-            setTimeout(() => resolve(resolve(errStatus('Timeout'))), 2000)
+            setTimeout(() => resolve(resolve(errStatus('Timeout'))), 2000);
             this.socket.onClose(message => resolve(errStatus(message)));
             this.socket.onMessage(data => {
                 const message = parse<SerializedReply<ReplyT>>(data);

--- a/packages/rpc/common/src/ts/websocket/WebSocketRequestReplyStub.ts
+++ b/packages/rpc/common/src/ts/websocket/WebSocketRequestReplyStub.ts
@@ -16,6 +16,7 @@ export class WebSocketRequestReplyStub implements RequestReplyStub {
     public async execute<ReplyT, ArgsT>(method: string, args: ArgsT): ReplyPromise<ReplyT> {
         const requestId: number = this.sequential.next();
         const result = new Promise<Reply<ReplyT>>((resolve) => {
+            setTimeout(() => resolve(resolve(errStatus("Timeout"))), 2000)
             this.socket.onClose(message => resolve(errStatus(message)));
             this.socket.onMessage(data => {
                 const message = parse<SerializedReply<ReplyT>>(data);

--- a/packages/rpc/common/tsconfig.json
+++ b/packages/rpc/common/tsconfig.json
@@ -8,6 +8,9 @@
       {
         "transform": "ts-type-checked/transformer"
       }
+    ],
+    "lib": [
+      "dom"
     ]
   }
 }


### PR DESCRIPTION
Prevents the WebSocketRequestReplyStub from crashing when there is no connection to the server

Closes https://github.com/0cfg/rpc/issues/ISSUE_NUMBER

# Def. of Done
- [ ] Changes described in changelog.md 📝 
- [ ] Automatic tests written 🧪
- [ ] Manually tested 🧪
- [ ] Good code style
- [ ] Necessary migrate instructions added to migrate.md 🚀
- [ ] No known issues
